### PR TITLE
fix(slot): rtl 配置不生效

### DIFF
--- a/src/slots/RtlSwitch/index.tsx
+++ b/src/slots/RtlSwitch/index.tsx
@@ -2,6 +2,7 @@ import { useContext, type FC } from 'react';
 import { css } from '@emotion/react';
 import type { SiteContextProps } from '../SiteContext';
 import SiteContext from '../SiteContext';
+import useAdditionalThemeConfig from '../../hooks/useAdditionalThemeConfig';
 import SwitchBtn from '../Header/SwitchBtn';
 import LTRIcon from '../../icons/LTRIcon';
 import RTLIcon from '../../icons/RTLIcon';
@@ -17,6 +18,9 @@ const useStyle = () => {
 const RtlSwitch: FC = () => {
   const { direction, updateSiteConfig } = useContext<SiteContextProps>(SiteContext);
   const { dataDirectionIcon } = useStyle();
+  const { rtl } = useAdditionalThemeConfig();
+
+  if (!rtl) return null;
 
   const onDirectionChange = () => {
     updateSiteConfig({ direction: direction !== 'rtl' ? 'rtl' : 'ltr' });


### PR DESCRIPTION
[dumi 源码](https://github.com/umijs/dumi/blob/86dde13181d2deadcaa601cb7529b603d7e52e2f/src/client/theme-default/slots/RtlSwitch/index.tsx#L21C30-L21C30)

```python
const { themeConfig } = useSiteData();
...
if (!themeConfig.rtl) return null;
```