### PR TITLE
fix(home): Button 组件未正确设置 key

### DIFF
--- a/src/layouts/HomePageLayout/index.tsx
+++ b/src/layouts/HomePageLayout/index.tsx
@@ -173,7 +173,7 @@ const Homepage: FC = () => {
           >
             {actions?.map(({ link, text, type }) => {
               return /^(\w+:)\/\/|^(mailto|tel):/.test(link) ? (
-                <Button size="large" type={type} href={link} target="_blank">
+                <Button size="large" type={type} href={link} target="_blank" key={link}>
                   {text}
                 </Button>
               ) : (


### PR DESCRIPTION
Warning: Each child in a list should have a unique "key" prop.