### PR TITLE
fix(slot): 导航链接使用外链时不会正确设置 a 标签的 href

### DIFF
--- a/src/slots/Header/Navigation.tsx
+++ b/src/slots/Header/Navigation.tsx
@@ -95,10 +95,15 @@ export default function Navigation({ isMobile, responsive }: NavigationProps) {
 
   // @ts-ignore
   const menuItems: MenuProps['items'] = (navList ?? []).map((navItem) => {
-    const linkKeyValue = navItem.link.split('/').slice(0, 2).join('/');
     return {
-      label: <Link to={`${navItem.link}${search}`}>{navItem.title}</Link>,
-      key: linkKeyValue
+      label: navItem.link && /^(\w+:)\/\/|^(mailto|tel):/.test(navItem.link) ? (
+            <a href={`${navItem.link}${search}`} target="_blank" rel="noreferrer">
+              {navItem.title}
+            </a>
+          ) : (
+            <Link to={`${navItem.link}${search}`}>{navItem.title}</Link>
+          ),
+      key: navItem.link
     };
   });
 


### PR DESCRIPTION
不过这也会导致一个问题，点击导航跳转之后，该标签会处于 active 状态