### PR TITLE
fix(menu): Should not import the named export 'version'

### DIFF
--- a/src/hooks/useMenu.tsx
+++ b/src/hooks/useMenu.tsx
@@ -14,7 +14,7 @@ import type {
 } from '../types';
 import { removeTitleCode, handleFullSidebarData } from '../utils';
 import useAdditionalThemeConfig from './useAdditionalThemeConfig';
-import { version } from '../../package.json';
+import pkgJSON from '../../package.json';
 
 export type UseMenuOptions = {
   before?: ReactNode;
@@ -116,7 +116,7 @@ const useMenu = (options: UseMenuOptions = {}): [MenuProps['items'], string] => 
           bordered={false}
           style={{ marginInlineStart: 'auto', marginInlineEnd: 0, marginTop: -2 }}
         >
-          {(typeof tag === 'string' ? tag : tag.title).replace('VERSION', `v${version}`)}
+          {(typeof tag === 'string' ? tag : tag.title).replace('VERSION', `v${pkgJSON.version}`)}
         </Tag>
       );
 


### PR DESCRIPTION
控制台会出现警告信息 [Error: Should not import the named export 'version' (imported as 'version')](https://stackoverflow.com/questions/64993118/error-should-not-import-the-named-export-version-imported-as-version)